### PR TITLE
Phase1 Quality of Life Improvements

### DIFF
--- a/AdventOfCodeScaffolding.csproj
+++ b/AdventOfCodeScaffolding.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Library</OutputType>
-    <TargetFramework>netcoreapp3.1</TargetFramework>
+    <TargetFramework>net5.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <ApplicationIcon></ApplicationIcon>
   </PropertyGroup>

--- a/ChallengeBase.cs
+++ b/ChallengeBase.cs
@@ -32,6 +32,7 @@ namespace AdventOfCodeScaffolding
 		{
             this.CancellationTokenSource = new CancellationTokenSource();
             this.CancellationToken = this.CancellationTokenSource.Token;
+            this.Logger = new NotReadyLogger();
         }
 
         /// <summary>
@@ -43,7 +44,38 @@ namespace AdventOfCodeScaffolding
             this.CancellationToken.ThrowIfCancellationRequested();
         }
 
+        /// <summary>
+        /// Enables convenient log output to the scaffolding Log Window, including automatic indentation within contextual blocks.
+        /// </summary>
+        /// <remarks>
+        /// Log output is appended to the content of the log even when the log window is not visible.
+        /// Do not log excessively.  The log accumulates in memory until manually cleared or the program is exitted.
+        /// 
+        /// Use only within part runs - do not use within challenge constructor (if any) or InvalidOperationException will be thrown
+        /// from any method call.
+        /// </remarks>
+        protected ILogger Logger {get; private set;}
+
 		internal CancellationTokenSource CancellationTokenSource {get;}
         private CancellationToken CancellationToken {get;}
+
+        internal ILogger InternalLogger
+        {
+            get {return Logger;}
+            set {Logger = value;}
+        }
+
+		internal class NotReadyLogger : ILogger
+		{
+			public IDisposable Context(string section)
+			{
+                throw new InvalidOperationException("Cannot use ChallengeBase.Logger outside of part runs.");
+			}
+
+			public void LogLine(string message)
+			{
+                throw new InvalidOperationException("Cannot use ChallengeBase.Logger outside of part runs.");
+			}
+		}
 	}
 }

--- a/ChallengeBase.cs
+++ b/ChallengeBase.cs
@@ -34,12 +34,16 @@ namespace AdventOfCodeScaffolding
             this.CancellationToken = this.CancellationTokenSource.Token;
         }
 
+        /// <summary>
+        /// Will throw an OperationCanceledException if the user hits the Cancel button since running this challenge.
+        /// Please call this during inner loops at convenient places if the calculation may be very long.
+        /// </summary>
         protected void AllowCancel()
         {
             this.CancellationToken.ThrowIfCancellationRequested();
         }
 
 		internal CancellationTokenSource CancellationTokenSource {get;}
-        protected CancellationToken CancellationToken {get;}
+        private CancellationToken CancellationToken {get;}
 	}
 }

--- a/ChallengeBase.cs
+++ b/ChallengeBase.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Text;
+using System.Threading;
 
 namespace AdventOfCodeScaffolding
 {
@@ -26,5 +27,19 @@ namespace AdventOfCodeScaffolding
 
         public virtual object Part2(string input) => throw new NotImplementedException();
         public virtual void Part2Test() => throw new NotImplementedException();
-    }
+
+		protected ChallengeBase()
+		{
+            this.CancellationTokenSource = new CancellationTokenSource();
+            this.CancellationToken = this.CancellationTokenSource.Token;
+        }
+
+        protected void AllowCancel()
+        {
+            this.CancellationToken.ThrowIfCancellationRequested();
+        }
+
+		internal CancellationTokenSource CancellationTokenSource {get;}
+        protected CancellationToken CancellationToken {get;}
+	}
 }

--- a/ILogger.cs
+++ b/ILogger.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AdventOfCodeScaffolding
+{
+	interface ILogger
+	{
+	}
+}

--- a/ILogger.cs
+++ b/ILogger.cs
@@ -6,7 +6,69 @@ using System.Threading.Tasks;
 
 namespace AdventOfCodeScaffolding
 {
-	interface ILogger
+	/// <summary>
+	/// Standard interface for writing to a text-based log, with support for automatic indentation within Context blocks.
+	/// </summary>
+	/// <remarks>
+	/// NOT THREADSAFE.  If your challenge has only one thread, you don't need to do anything else to be safe.
+	/// If your challenge has more than one thread, you must either log only from the main thread (which called Part1() or Part2())
+	/// or manually synchronize so only one thread calls at a time.  In no case should you allow any thread you create to make use of this
+	/// interface after the corresponding Part1() or Part2() call returns.
+	/// </remarks>
+	public interface ILogger
 	{
+	#region basic members
+
+		/// <summary>
+		/// Logs a message as a line (appending newline).
+		/// </summary>
+		/// <param name="message">The message to be logged.  May be null, which is treated as an empty string.
+		/// May be multiple lines (containing LF or CR/LF any number of times), in which case each line is separately indented
+		/// as necessary for consistent indentation of the entire message.</param>
+		void LogLine(string message);
+
+		/// <summary>
+		/// Logs a section header as a line (appending newline) and indents all subsequent lines, until the returned value is disposed.
+		/// Intended to be used exclusively within using() statements.
+		/// </summary>
+		/// <param name="section">The section message to be logged to give "context" to the subsequently indented lines.
+		/// The section message is essentially written via a direct call to LogLine(section) before increasing the indent count.
+		/// See LogLine() for details.
+		/// </param>
+		IDisposable Context(string section);
+
+	#endregion // basic members
+
+
+	#region convenience members
+
+		/// <summary>
+		/// Logs a section header as a line and indents all subsequent lines, until the returned value is disposed.
+		/// Intended to be used exclusively within using() statements.  Null is treated as an empty header.
+		/// </summary>
+		IDisposable Context<T>(T section) => Context(section?.ToString() ?? string.Empty);
+
+		/// <summary>
+		/// Logs an object as a message line (via ToString() and appending newline).  Null is logged as an empty line.
+		/// </summary>
+		void LogLine<T>(T message) => LogLine(message?.ToString() ?? string.Empty);
+
+		/// <summary>
+		/// Logs an empty line.
+		/// </summary>
+		void LogLine() => LogLine(string.Empty);
+
+		/// <summary>
+		/// Logs an exception in a standard way, by first using Context("EXCEPTION") then logging the details of the exception
+		/// via ex.ToString(), unless ex is null, in which case the line logged is "(ex == null)".  In either case, the context
+		/// is automatically disposed.
+		/// </summary>
+		void LogException(Exception ex)
+		{
+			using (Context("EXCEPTION:"))
+				LogLine(ex?.ToString() ?? "(ex == null)");
+		}
+
+	#endregion // convenience members
 	}
 }

--- a/Metrics.cs
+++ b/Metrics.cs
@@ -10,16 +10,19 @@ namespace AdventOfCodeScaffolding.Util
     {
         public static readonly Metrics Empty = new Metrics(new List<long>(0));
 
-        public static Metrics Measure(long maxMilliseconds, int minReps, Action action)
+        private const long tpus = TimeSpan.TicksPerMillisecond / 1000;
+
+        public static Metrics Measure(long maxMilliseconds, int minReps, Action action, bool runOnceOnly = false)
         {
             var times = new List<long>(minReps);
             var totalTime = Stopwatch.StartNew();
-            const long tpus = TimeSpan.TicksPerMillisecond / 1000;
             for (int i = 0; i < minReps || totalTime.ElapsedMilliseconds < maxMilliseconds; i++)
             {
                 var timer = Stopwatch.StartNew();
                 action();
                 times.Add(timer.Elapsed.Ticks / tpus);
+                if (runOnceOnly)
+                    break;
             }
 
             return new Metrics(times);

--- a/UI/LogWindow.xaml
+++ b/UI/LogWindow.xaml
@@ -7,6 +7,24 @@
         mc:Ignorable="d"
         Title="LogWindow" Height="450" Width="800">
     <Grid>
-        
-    </Grid>
+		<Grid.ColumnDefinitions>
+			<ColumnDefinition Width="Auto"/>
+			<ColumnDefinition Width="1*"/>
+			<ColumnDefinition Width="Auto"/>
+		</Grid.ColumnDefinitions>
+		<Grid.RowDefinitions>
+			<RowDefinition Height="Auto"/>
+			<RowDefinition Height="1*"/>
+			<RowDefinition Height="Auto"/>
+		</Grid.RowDefinitions>
+		<TextBox
+			Grid.Column="0" Grid.ColumnSpan="3" Grid.Row="1" FontFamily="Lucida Console"
+			IsReadOnly="true" TextWrapping="NoWrap"
+			HorizontalScrollBarVisibility="Visible" VerticalScrollBarVisibility="Visible"
+			Name="logTextBox"
+		/>
+		<CheckBox Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2"
+			Content="Live Update" VerticalAlignment="Center" HorizontalAlignment="Left" Visibility="Hidden"/>
+		<Button Grid.Column="2" Grid.Row="0" Content="Clear" Margin="0,4,4,4" MinWidth="60" Padding="5" Click="Clear_Click"/>
+	</Grid>
 </Window>

--- a/UI/LogWindow.xaml
+++ b/UI/LogWindow.xaml
@@ -1,0 +1,12 @@
+﻿<Window x:Class="AdventOfCodeScaffolding.UI.LogWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:local="clr-namespace:AdventOfCodeScaffolding.UI"
+        mc:Ignorable="d"
+        Title="LogWindow" Height="450" Width="800">
+    <Grid>
+        
+    </Grid>
+</Window>

--- a/UI/LogWindow.xaml.cs
+++ b/UI/LogWindow.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Documents;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using System.Windows.Shapes;
+
+namespace AdventOfCodeScaffolding.UI
+{
+	/// <summary>
+	/// Interaction logic for LogWindow.xaml
+	/// </summary>
+	public partial class LogWindow : Window
+	{
+		public LogWindow()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/UI/LogWindow.xaml.cs
+++ b/UI/LogWindow.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -15,18 +16,231 @@ using System.Windows.Shapes;
 namespace AdventOfCodeScaffolding.UI
 {
 	/// <summary>
-	/// Interaction logic for LogWindow.xaml
+	/// Interaction logic for LogWindow.xaml.  Application must ensure there is only
+	/// one such non-closed window at a time.
 	/// </summary>
 	public partial class LogWindow : Window
 	{
+		/*
+		 * How this works:
+		 * 
+		 * MainWindow ensures there's only zero or one LogWindow active (not-closed)
+		 * at a time.
+		 * 
+		 * LogWindow has its own simple, private, singleton implementation of ILogger.
+		 * 
+		 * That Logger uses a concurrent FIFO queue for incoming calls on the interface,
+		 * then raises an event after each call, which LogWindow consumes by using
+		 * Dispatcher.Invoke() to handle those events on the UI thread.
+		 * 
+		 * The UI work happens in UpdateLogView() always on the UI thread in a safe manner.
+		 * 
+		 * When the LogWindow is closed, a flag is set so that UpdateLogView() will do
+		 * nothing, even if some trailing calls are incoming.  After that flag is set,
+		 * the state is saved in a static variable for carry over to the next instance
+		 * of the LogWindow, if any.  State is then restored before the Logger_LogUpdate
+		 * event is subscribed, the next time the LogWindow is shown.
+		 * 
+		 * This arrangement (specific responsibilities and sequence of events) is designed
+		 * to guarantee that:
+		 * 
+		 * 1. No log events are lost,
+		 * 2. No log events are processed out of order.
+		 * 3. The data for each log event is only rooted in one place at a time.
+		 * 
+		 * In short: this design makes the LogWindow reliable and memory efficient.
+		 * 
+		 * The reliability would be more simply gained by having the Logger itself
+		 * maintain state, but that would come at the expense of duplicated storage for
+		 * the accumulating log text.  The current design is much more memory efficient
+		 * for cases where there is a huge volume of log events.  In that case,
+		 * each log event is exclusively stored either in the Queue, in the 
+		 * CarryOverState when the LogWindow is closed, or in the LogWindow.TexBox
+		 * when the LogWindow is visible.  No wasted memory.
+		 * 
+		 */
+
+		private static readonly Logger logger = new();
+		internal static ILogger SingletonLogger => logger;
+
 		public LogWindow()
 		{
 			InitializeComponent();
+
+			depth = carryOverState?.Depth ?? 0;
+			logTextBox.Text = carryOverState?.AllText ?? "";
+
+			logger.LogUpdated += Logger_LogUpdated;
+			this.Closed += LogWindow_Closed;
+
+			this.Loaded += LogWindow_Loaded;
 		}
 
-		internal static ILogger CreateLogger()
+		private void LogWindow_Loaded(object sender, RoutedEventArgs e)
 		{
-			throw new NotImplementedException();
+			UpdateLogView();
+			logTextBox.ScrollToEnd();
+		}
+
+		private bool closed = false;
+
+		private record CarryOverState
+		{
+			public int Depth {get; init;}
+			public string AllText {get; init;}
+		}
+
+		private static CarryOverState carryOverState = null;
+
+		private void LogWindow_Closed(object sender, EventArgs e)
+		{
+			logger.LogUpdated -= Logger_LogUpdated;
+			closed = true;
+			carryOverState = new CarryOverState{Depth = depth, AllText = logTextBox.Text};
+		}
+
+		private void Logger_LogUpdated()
+		{
+			Dispatcher.Invoke(UpdateLogView);
+		}
+
+		private void Clear_Click(object sender, RoutedEventArgs e)
+		{
+			logTextBox.Clear();
+		}
+
+		private int depth = 0;
+
+		private void UpdateLogView()
+		{
+			if (closed)
+				return;
+
+			StringBuilder sb = null;
+
+			bool anyUpdate = false;
+
+			while (logger.Queue.TryDequeue(out var logEvent))
+			{
+				if (!anyUpdate)
+					sb = new StringBuilder();
+
+				anyUpdate = true;
+
+				switch (logEvent.Type)
+				{
+					case LogType.EnterContext:
+						AppendIndentedLines(sb, logEvent.Text);
+						depth++;
+						break;
+
+					case LogType.LogLine:
+						AppendIndentedLines(sb, logEvent.Text);
+						break;
+
+					case LogType.LeaveContext:
+						depth--;
+						break;
+
+					default:
+						throw new Exception($"Unexpected logEvent.Type: {logEvent.Type} ({(int)logEvent.Type})");
+				}
+			}
+
+			if (anyUpdate)
+			{
+				var newText = sb.ToString();
+				logTextBox.AppendText(newText);
+
+				logTextBox.ScrollToEnd();
+			}
+		}
+
+		private void AppendIndentedLines(StringBuilder sb, string text)
+		{
+			foreach (var line in (text ?? string.Empty).Split('\n'))
+			{
+				sb.Append(new string('\t', depth));
+				sb.Append(line.TrimEnd('\r'));
+				sb.Append('\n');
+			}
+		}
+
+		private enum LogType
+		{
+			None = 0,
+
+			EnterContext = 1,
+			LogLine = 2,
+			LeaveContext = 3
+		}
+
+		private record LogEvent
+		{
+			public LogType Type { get; init; }
+			public string Text { get; init; }
+		}
+
+		private class Logger : ILogger
+		{
+			internal ConcurrentQueue<LogEvent> Queue {get;}
+			
+			internal delegate void LogUpdatedEventHandler();
+			internal event LogUpdatedEventHandler LogUpdated;
+
+			internal Logger()
+			{
+				this.Queue = new ConcurrentQueue<LogEvent>();
+			}
+
+			IDisposable ILogger.Context(string section)
+			{
+				Queue.Enqueue(new LogEvent{Type = LogType.EnterContext, Text = section});
+				LogUpdated?.Invoke();
+				return new Context(this);
+			}
+
+			void ILogger.LogLine(string message)
+			{
+				Queue.Enqueue(new LogEvent{Type = LogType.LogLine, Text = message});
+				LogUpdated?.Invoke();
+			}
+
+			private void LeaveContext()
+			{
+				Queue.Enqueue(new LogEvent{Type = LogType.LeaveContext, Text = null});
+				LogUpdated?.Invoke();
+			}
+
+			private class Context : IDisposable
+			{
+				private readonly Logger logger;
+				internal Context(Logger logger)
+				{
+					this.logger = logger;
+				}
+
+				private bool disposedValue = false;
+
+				protected virtual void Dispose(bool disposing)
+				{
+					if (!disposedValue)
+					{
+						if (disposing)
+						{
+							logger.LeaveContext();
+						}
+
+						disposedValue = true;
+					}
+				}
+
+				public void Dispose()
+				{
+					Dispose(disposing: true);
+					GC.SuppressFinalize(this);
+				}
+			}
 		}
 	}
 }

--- a/UI/LogWindow.xaml.cs
+++ b/UI/LogWindow.xaml.cs
@@ -23,5 +23,10 @@ namespace AdventOfCodeScaffolding.UI
 		{
 			InitializeComponent();
 		}
+
+		internal static ILogger CreateLogger()
+		{
+			throw new NotImplementedException();
+		}
 	}
 }

--- a/UI/MainWindow.xaml
+++ b/UI/MainWindow.xaml
@@ -6,6 +6,10 @@
         xmlns:local="clr-namespace:AdventOfCodeScaffolding.UI"
         mc:Ignorable="d"
         Title="Advent of code" Height="450" Width="800" Icon="../Resources/Calendar_16x.ico">
+	<Window.Resources>
+		<local:InverseBooleanConverter x:Key="InverseBooleanConverter" />
+		<local:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+	</Window.Resources>
     <Grid>
         <Grid.ColumnDefinitions>
             <ColumnDefinition Width="1*"/>
@@ -36,13 +40,26 @@
                     DisplayMemberPath="Name"
                     VerticalContentAlignment="Center"
                 />
-			<Button Margin="0,4,4,4" MinWidth="60" Content="Run" Grid.Row="0" Grid.Column="1" Padding="5" Click="Run_Click"/>
+			<Button Margin="0,4,4,4" MinWidth="60" Content="Run" IsEnabled="{Binding Path=IsRunning, Converter={StaticResource InverseBooleanConverter}}" Grid.Row="0" Grid.Column="1" Padding="5" Click="Run_Click"/>
 		</Grid>
         <local:OutputPane Title="Part 1" x:Name="Part1" Grid.Column="1" Grid.Row="0"/>
         <local:OutputPane Title="Part 2" x:Name="Part2" Grid.Column="1" Grid.Row="1"/>
-		<CheckBox Margin="4,4,12,4" Content="Enable Benchmarking"
-            Grid.Row="3" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right"
-            IsChecked="{Binding Path=EnableBenchmarking}"
+		<Grid Grid.Column="1" Grid.Row="2">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="Auto"/>
+				<ColumnDefinition Width="1*"/>
+				<ColumnDefinition Width="Auto"/>
+			</Grid.ColumnDefinitions>
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto"/>
+			</Grid.RowDefinitions>
+			<Button Margin="0,4,4,4" MinWidth="60" Content="Cancel" Visibility="{Binding Path=IsRunning, Converter={StaticResource BooleanToVisibilityConverter}}" Grid.Row="0" Grid.Column="0" Padding="5" Click="Cancel_Click"/>
+			<CheckBox Margin="4,4,12,4" Content="Enable Benchmarking"
+                Grid.Row="0" Grid.Column="1" VerticalAlignment="Center" HorizontalAlignment="Left"
+                IsChecked="{Binding Path=EnableBenchmarking}"
             />
+			<Button Margin="0,4,4,4" MinWidth="60" Content="Show Log" Grid.Row="0" Grid.Column="2" Padding="5" Click="ShowLog_Click"/>
+		</Grid>
+		
 	</Grid>
 </Window>

--- a/UI/MainWindow.xaml
+++ b/UI/MainWindow.xaml
@@ -8,38 +8,41 @@
         Title="Advent of code" Height="450" Width="800" Icon="../Resources/Calendar_16x.ico">
     <Grid>
         <Grid.ColumnDefinitions>
-            <ColumnDefinition />
-            <ColumnDefinition />
+            <ColumnDefinition Width="1*"/>
+            <ColumnDefinition Width="1*"/>
         </Grid.ColumnDefinitions>
         <Grid.RowDefinitions>
-            <RowDefinition/>
-            <RowDefinition/>
-        </Grid.RowDefinitions>
-        <GroupBox Padding="3" Header="Input" Grid.Row="0" Grid.RowSpan="2">
-            <Grid Grid.Column="0" Grid.RowSpan="2">
-                <Grid.ColumnDefinitions>
-                    <ColumnDefinition Width="*"/>
-                    <ColumnDefinition Width="Auto" />
-                </Grid.ColumnDefinitions>
-                <Grid.RowDefinitions>
-                    <RowDefinition Height="*"/>
-                    <RowDefinition Height="Auto"/>
-                </Grid.RowDefinitions>
-                <TextBox Grid.ColumnSpan="2" Text="{Binding Input}" TextWrapping="NoWrap" AcceptsReturn="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Visible"/>
-
-                <ComboBox
-                    Margin="0,4,4,0"
-                    Grid.Row="1"
+            <RowDefinition Height="1*"/>
+            <RowDefinition Height="1*"/>
+			<RowDefinition Height="Auto"/>
+		</Grid.RowDefinitions>
+        <GroupBox Padding="3" Header="Input" Grid.Column="0" Grid.Row="0" Grid.RowSpan="2">
+            <TextBox Grid.ColumnSpan="2" Text="{Binding Input}" TextWrapping="NoWrap" AcceptsReturn="True" HorizontalScrollBarVisibility="Auto" VerticalScrollBarVisibility="Visible"/>
+        </GroupBox>
+		<Grid Grid.Column="0" Grid.Row="2">
+			<Grid.ColumnDefinitions>
+				<ColumnDefinition Width="1*"/>
+				<ColumnDefinition Width="Auto"/>
+			</Grid.ColumnDefinitions>
+			<Grid.RowDefinitions>
+				<RowDefinition Height="Auto"/>
+			</Grid.RowDefinitions>
+			<ComboBox
+                    Margin="4,4,4,4"
+                    Grid.Row="0"
                     Grid.Column="0"
                     ItemsSource="{Binding Challenges}"
                     SelectedItem="{Binding SelectedChallenge}"
                     DisplayMemberPath="Name"
                     VerticalContentAlignment="Center"
                 />
-                <Button Margin="0,4,0,0" MinWidth="60" Content="Run" Grid.Row="1" Grid.Column="1" Padding="5" Click="Run_Click"/>
-            </Grid>
-        </GroupBox>
-        <local:OutputPane Title="Part 1" x:Name="Part1" Grid.Column="1" />
+			<Button Margin="0,4,4,4" MinWidth="60" Content="Run" Grid.Row="0" Grid.Column="1" Padding="5" Click="Run_Click"/>
+		</Grid>
+        <local:OutputPane Title="Part 1" x:Name="Part1" Grid.Column="1" Grid.Row="0"/>
         <local:OutputPane Title="Part 2" x:Name="Part2" Grid.Column="1" Grid.Row="1"/>
-    </Grid>
+		<CheckBox Margin="4,4,12,4" Content="Enable Benchmarking"
+            Grid.Row="3" Grid.Column="2" VerticalAlignment="Center" HorizontalAlignment="Right"
+            IsChecked="{Binding Path=EnableBenchmarking}"
+            />
+	</Grid>
 </Window>

--- a/UI/MainWindow.xaml.cs
+++ b/UI/MainWindow.xaml.cs
@@ -83,12 +83,12 @@ namespace AdventOfCodeScaffolding.UI
                     try
                     {
                         part = 1;
-                        pt1Result = Measure(() => instance.Part1(Input), out pt1Metrics, benchmark);
+                        pt1Result = Measure(() => instance.Part1(Input), out pt1Metrics, benchmark, cancelToken);
 
                         cancelToken.ThrowIfCancellationRequested();
 
                         part = 2;
-                        pt2Result = Measure(() => instance.Part2(Input), out pt2Metrics, benchmark);
+                        pt2Result = Measure(() => instance.Part2(Input), out pt2Metrics, benchmark, cancelToken);
 
                         part = 3;
                     }
@@ -121,7 +121,7 @@ namespace AdventOfCodeScaffolding.UI
             cancelTokenSource?.Cancel();
 		}
 
-        private static object Measure(Func<object> action, out Metrics metrics, bool benchmark)
+        private static object Measure(Func<object> action, out Metrics metrics, bool benchmark, CancellationToken cancelToken)
         {
             try
             {
@@ -132,6 +132,8 @@ namespace AdventOfCodeScaffolding.UI
                     runOnceOnly: !benchmark,
                     action: () =>
                 {
+                    cancelToken.ThrowIfCancellationRequested();
+
                     var newResult = action();
                     if (result != null && !result.Equals(newResult))
                         throw new Exception($"Result differed between test runs! Old: {result}, New: {newResult}");

--- a/UI/MainWindow.xaml.cs
+++ b/UI/MainWindow.xaml.cs
@@ -41,7 +41,7 @@ namespace AdventOfCodeScaffolding.UI
 
         public MainWindow()
         {
-            this.Logger = LogWindow.CreateLogger();
+            this.Logger = LogWindow.SingletonLogger;
 
             InitializeComponent();
             DataContext = this;
@@ -83,8 +83,7 @@ namespace AdventOfCodeScaffolding.UI
 
             IsRunning = true;
 
-            // since the run may be long, and the UI could allow selecting another challenge mid-run, we must cache day/name for reliable logging.
-            var selectedChallengeDay = SelectedChallenge.Day;
+            // since the run may be long, and the UI could allow selecting another challenge mid-run, we must cache name for reliable logging.
             var selectedChallengeName = SelectedChallenge.Name;
 
             await Task.Run(() =>
@@ -94,7 +93,7 @@ namespace AdventOfCodeScaffolding.UI
 					{
 						void logPartHeading()
 						{
-							Logger.LogLine($"\n\n====== Running: Day {selectedChallengeDay} - {selectedChallengeName}, Part {part} ======\n");
+							Logger.LogLine($"\n\n====== Running: {selectedChallengeName}, Part {part} ======\n");
 						}
 
 						part = 1;

--- a/UI/MainWindow.xaml.cs
+++ b/UI/MainWindow.xaml.cs
@@ -68,7 +68,11 @@ namespace AdventOfCodeScaffolding.UI
             try
             {
                 object result = null;
-                metrics = Metrics.Measure(maxMilliseconds: 150, minReps: 10, () =>
+                metrics = Metrics.Measure(
+                    maxMilliseconds: 150, 
+                    minReps: 10, 
+                    runOnceOnly: !EnableBenchmarking,
+                    action: () =>
                 {
                     var newResult = action();
                     if (result != null && !result.Equals(newResult))
@@ -152,5 +156,14 @@ namespace AdventOfCodeScaffolding.UI
             DependencyProperty.Register("SelectedChallenge",
             typeof(ChallengeInfo), typeof(MainWindow),
             new PropertyMetadata(null, (s, e) => ((MainWindow)s).UpdateTestResults((ChallengeInfo) e.NewValue)));
-    }
+
+		public bool EnableBenchmarking
+		{
+			get { return (bool)GetValue(EnableBenchmarkingProperty); }
+			set { SetValue(EnableBenchmarkingProperty, value); }
+		}
+
+		public static readonly DependencyProperty EnableBenchmarkingProperty =
+			DependencyProperty.Register("EnableBenchmarking", typeof(bool), typeof(MainWindow), new UIPropertyMetadata(true));
+	}
 }

--- a/UI/MainWindow.xaml.cs
+++ b/UI/MainWindow.xaml.cs
@@ -48,9 +48,11 @@ namespace AdventOfCodeScaffolding.UI
                 .ToList();
 
             SelectedChallenge = Challenges.LastOrDefault();
+
+            Application.Current.ShutdownMode = ShutdownMode.OnMainWindowClose;
         }
 
-        private void Run_Click(object sender, RoutedEventArgs e)
+		private void Run_Click(object sender, RoutedEventArgs e)
         {
             if (SelectedChallenge == null)
                 return;
@@ -62,6 +64,10 @@ namespace AdventOfCodeScaffolding.UI
             Part1.Update(pt1Result, pt1Metrics);
             Part2.Update(pt2Result, pt2Metrics);
         }
+
+        private void Cancel_Click(object sender, RoutedEventArgs e)
+		{
+		}
 
         private object Measure(Func<object> action, out Metrics metrics)
         {
@@ -165,5 +171,48 @@ namespace AdventOfCodeScaffolding.UI
 
 		public static readonly DependencyProperty EnableBenchmarkingProperty =
 			DependencyProperty.Register("EnableBenchmarking", typeof(bool), typeof(MainWindow), new UIPropertyMetadata(true));
+
+		public bool IsRunning
+		{
+			get { return (bool)GetValue(IsRunningProperty); }
+			set { SetValue(IsRunningProperty, value); }
+		}
+
+		public static readonly DependencyProperty IsRunningProperty =
+			DependencyProperty.Register("IsRunning", typeof(bool), typeof(MainWindow), new PropertyMetadata(false));
+
+
+		#region Log Window
+
+		private LogWindow logWindow = null;
+
+        void ShowLogWindow()
+        {
+            if (logWindow == null)
+            {
+                logWindow = new LogWindow();
+			    logWindow.Closed += LogWindow_Closed;
+            }
+
+            logWindow.Show();
+            logWindow.Activate();
+        }
+
+        void CloseLogWindow()
+        {
+            logWindow?.Close();
+        }
+
+		private void LogWindow_Closed(object sender, EventArgs e)
+		{
+            logWindow = null;
+		}
+
+		private void ShowLog_Click(object sender, RoutedEventArgs e)
+		{
+            ShowLogWindow();
+		}
+
+		#endregion // Log Window
 	}
 }

--- a/UI/MainWindow.xaml.cs
+++ b/UI/MainWindow.xaml.cs
@@ -74,7 +74,7 @@ namespace AdventOfCodeScaffolding.UI
             Part1.Update(pt1Result, pt1Metrics);
             Part2.Update(pt2Result, pt2Metrics);
 
-            pt1Result = pt2Result = "!! Incomplete Run !!";
+            pt1Result = pt2Result = "(did not run)";
 
             bool benchmark = EnableBenchmarking;
 
@@ -93,7 +93,7 @@ namespace AdventOfCodeScaffolding.UI
 					{
 						void logPartHeading()
 						{
-							Logger.LogLine($"\n\n====== Running: {selectedChallengeName}, Part {part} ======\n");
+							Logger.LogLine($"====== Running: {selectedChallengeName}, Part {part} ======");
 						}
 
 						part = 1;
@@ -106,7 +106,7 @@ namespace AdventOfCodeScaffolding.UI
 						logPartHeading();
 						pt2Result = Measure(() => instance.Part2(Input), out pt2Metrics, benchmark, cancelToken);
 
-						Logger.LogLine("\n====== Done ======");
+						Logger.LogLine("====== Done ======");
 						part = 3;
 					}
 					catch (Exception ex)

--- a/UIHelpers/BooleanToVisibilityConverter.cs
+++ b/UIHelpers/BooleanToVisibilityConverter.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+using System.Windows;
+
+namespace AdventOfCodeScaffolding.UI
+{
+	/// <summary>
+	/// Converts a boolean value to true = Visibility.Visible and false = Visibility.Hidden.
+	/// </summary>
+	[ValueConversion(typeof(bool), typeof(Visibility))]
+	public class BooleanToVisibilityConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (value is bool b && targetType == typeof(Visibility))
+				return b ? Visibility.Visible : Visibility.Hidden;
+			else
+				throw new InvalidOperationException("Target type must be Visibility and source must be boolean.");
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}

--- a/UIHelpers/InverseBooleanConverter.cs
+++ b/UIHelpers/InverseBooleanConverter.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Data;
+
+namespace AdventOfCodeScaffolding.UI
+{
+	/// <summary>
+	/// Converts a boolean value to its inverse.
+	/// </summary>
+	/// <remarks>
+	/// Based on <a href="https://stackoverflow.com/questions/1039636/how-to-bind-inverse-boolean-properties-in-wpf">
+	/// "How to bind inverse boolean properties in WPF?" on Stack Overflow</a>
+	/// </remarks>
+	[ValueConversion(typeof(bool), typeof(bool))]
+	public class InverseBooleanConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if (targetType != typeof(bool))
+				throw new InvalidOperationException("Target must be boolean.");
+
+			return !(bool)value;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotSupportedException();
+		}
+	}
+}


### PR DESCRIPTION
This first pull request updates the project to .Net 5 and contains a few Quality of Life improvements:

1. Benchmarking can be toggled via a checkbox.  Checked (default) = original behavior.  Unchecked = run once only.  This makes it easier to get a good time when competing for rank, especially if your code takes awhile to run.
2. Challenge code is run on a separate thread so the UI is still responsive even during long calculations.
3. Running challenges can be cancelled.  This requires the challenge code to call "AllowCancel()" within inner loops.  This is implemented via the standard CancellationToken pattern.  Even if the challenge does not call AllowCancel(), cancelling at least prevents subsequent benchmarking runs (if enabled).
4. Challenges now have access to base.Logger to log whatever they want to a separate Log Window.  The LogWindow can be closed or re-opened at any time without losing log events.  It can also be manually cleared.  Debouncing and a timer is used to make sure that even during prologned excessive logging, the UI is still usable and long-running calculations can still be cancelled.  The Logger methods follow the same signatures as Jake's TaskTool repo, to make usage familiar.